### PR TITLE
Fix report generation when running on a non-writable execution environment

### DIFF
--- a/inst/application/server.R
+++ b/inst/application/server.R
@@ -176,6 +176,11 @@ shinyServer(function(input, output, session) {
                     params$annotationTable = NA
                 }
 
+                report_path <- tempfile(fileext = ".Rmd")
+                tmp_path <- dirname(report_path)
+                file.copy("rmarkdown", tmp_path, recursive = TRUE, overwrite = TRUE)
+                file.copy("report.Rmd", report_path, overwrite = TRUE)
+                
                 rmarkdown::render("report.Rmd", output_file = fname,
                                   params = params,
                                   envir = new.env(parent = globalenv())


### PR DESCRIPTION
For some unkown reason, pandocs wants the Rmd file to be writable. To make this working when running in singularity, we make a copy of the Rmd file (and dependencies) in a tmp location.